### PR TITLE
Avoid unexpected panic in starts_with

### DIFF
--- a/src/borrowed.rs
+++ b/src/borrowed.rs
@@ -86,7 +86,12 @@ impl UncasedStr {
     /// ```
     #[inline(always)]
     pub fn starts_with(&self, string: &str) -> bool {
-        self.len() >= string.len() && self[..string.len()] == string
+        self.len() >= string.len()
+            && self
+                .as_str()
+                .get(..string.len())
+                .map(|s| Self::new(s) == string)
+                .unwrap_or(false)
     }
 
     /// Converts a `Box<UncasedStr>` into an `Uncased` without copying or

--- a/src/borrowed.rs
+++ b/src/borrowed.rs
@@ -86,12 +86,10 @@ impl UncasedStr {
     /// ```
     #[inline(always)]
     pub fn starts_with(&self, string: &str) -> bool {
-        self.len() >= string.len()
-            && self
-                .as_str()
-                .get(..string.len())
-                .map(|s| Self::new(s) == string)
-                .unwrap_or(false)
+        self.as_str()
+            .get(..string.len())
+            .map(|s| Self::new(s) == string)
+            .unwrap_or(false)
     }
 
     /// Converts a `Box<UncasedStr>` into an `Uncased` without copying or


### PR DESCRIPTION
Currently this code panics:

```rust
uncased::UncasedStr::new("è").starts_with("e")
```

with the following message:

```
thread 'main' panicked at 'byte index 1 is not a char boundary; it is inside 'è' (bytes 0..2) of `è`'
```

The reason is that `starts_with` contains an indexing operation that's not guaranteed to succeed. 
This PR fixes this by switching to `str::get`. 