### PR TITLE
Make `UncasedStr::new` a `const fn` on Rust 1.56+

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,4 +2,7 @@ fn main() {
     if let Some(true) = version_check::is_feature_flaggable() {
         println!("cargo:rustc-cfg=nightly");
     }
+    if let Some(true) = version_check::is_min_version("1.56.0") {
+        println!("cargo:rustc-cfg=const_fn_transmute");
+    }
 }

--- a/src/borrowed.rs
+++ b/src/borrowed.rs
@@ -22,6 +22,8 @@ pub struct UncasedStr(str);
 impl UncasedStr {
     /// Cost-free conversion from an `&str` reference to an `UncasedStr`.
     ///
+    /// This is a `const fn` on Rust 1.56+.
+    ///
     /// # Example
     ///
     /// ```rust
@@ -33,10 +35,33 @@ impl UncasedStr {
     /// assert_eq!(uncased_str, "HeLLo!");
     /// ```
     #[inline(always)]
+    #[cfg(not(const_fn_transmute))]
     pub fn new(string: &str) -> &UncasedStr {
         // This is a `newtype`-like transformation. `repr(transparent)` ensures
         // that this is safe and correct.
         unsafe { &*(string as *const str as *const UncasedStr) }
+    }
+
+    /// Cost-free conversion from an `&str` reference to an `UncasedStr`.
+    ///
+    /// This is a `const fn` on Rust 1.56+.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use uncased::UncasedStr;
+    ///
+    /// let uncased_str = UncasedStr::new("Hello!");
+    /// assert_eq!(uncased_str, "hello!");
+    /// assert_eq!(uncased_str, "Hello!");
+    /// assert_eq!(uncased_str, "HeLLo!");
+    /// ```
+    #[inline(always)]
+    #[cfg(const_fn_transmute)]
+    pub const fn new(string: &str) -> &UncasedStr {
+        // This is a `newtype`-like transformation. `repr(transparent)` ensures
+        // that this is safe and correct.
+        unsafe { core::mem::transmute(string) }
     }
 
     /// Returns `self` as an `&str`.


### PR DESCRIPTION
This is perhaps a bit premature, since Rust 1.56 hasn't shipped yet, but wanted to open for discussion. This is an alternative to #3.

----

In Rust 1.56, `mem::transmute` will be permitted in `const fn`s, which
means `UncasedStr::new` can become a `const fn`.

Being able to safely construct `UncasedStr`s in `consts` would be really
useful in rust-phf, which currently needs to roll its own `unsafe`:

https://github.com/rust-phf/rust-phf/blob/eba4cc28d/phf_shared/src/lib.rs#L308-L313