### PR TITLE
Impl FromStr for Uncased<'static>

### DIFF
--- a/src/owned.rs
+++ b/src/owned.rs
@@ -5,6 +5,7 @@ use core::ops::Deref;
 use core::cmp::Ordering;
 use core::hash::{Hash, Hasher};
 use core::fmt;
+use core::str::FromStr;
 
 use crate::UncasedStr;
 
@@ -214,6 +215,14 @@ impl<'s, 'c: 's> From<Cow<'c, str>> for Uncased<'s> {
     #[inline(always)]
     fn from(string: Cow<'c, str>) -> Self {
         Uncased::new(string)
+    }
+}
+
+impl FromStr for Uncased<'static> {
+    type Err = core::convert::Infallible;
+    #[inline]
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Uncased::from(String::from(s)))
     }
 }
 


### PR DESCRIPTION
This implementation is nearly identical to `String`'s implementation: https://github.com/rust-lang/rust/blob/8a12be741290b16c29293f87bdb3e8e5129bd4a9/library/alloc/src/string.rs#L2330-L2336

Rationale: I'm using `argh` for CLI argument parsing, and it can parse [anything that implements FromStr](https://docs.rs/argh/0.1.6/argh/trait.FromArgValue.html). Without this PR that doesn't include `Uncased` and makes it less convenient.